### PR TITLE
Chat UX redesign: visible conversation, calm palette, dark/light theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,16 @@
     <link rel="icon" type="favicon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MindMate</title>
+    <script>
+      // Apply saved theme before paint to avoid a flash
+      (function () {
+        try {
+          if (localStorage.getItem("theme") === "dark") {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/ChatHistorySidebar.jsx
+++ b/frontend/src/components/ChatHistorySidebar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { X, MessageCircle } from 'lucide-react';
+import { X, MessageCircle, ChevronLeft } from 'lucide-react';
 
 const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
@@ -45,9 +45,9 @@ const ChatHistoryModal = ({ isOpen, onClose }) => {
   }, [isOpen]);
 
   const formatDate = (dateString) => {
-    const options = { 
-      year: 'numeric', 
-      month: 'short', 
+    const options = {
+      year: 'numeric',
+      month: 'short',
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit'
@@ -55,65 +55,85 @@ const ChatHistoryModal = ({ isOpen, onClose }) => {
     return new Date(dateString).toLocaleDateString(undefined, options);
   };
 
+  const formatTime = (dateString) => {
+    if (!dateString) return "";
+    try {
+      return new Date(dateString).toLocaleTimeString(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return "";
+    }
+  };
+
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={(e) => {
+    <div className="fixed inset-0 bg-calm-ink/40 dark:bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={(e) => {
       if (e.target === e.currentTarget) onClose();
     }}>
-      <div className="bg-white rounded-lg w-[90%] max-w-3xl max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
+      <div className="bg-calm-surface dark:bg-calmd-surface rounded-2xl w-[90%] max-w-3xl max-h-[80vh] flex flex-col shadow-2xl" onClick={e => e.stopPropagation()}>
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b">
-          <h2 className="text-xl font-semibold">Chat History</h2>
-          <button 
+        <div className="flex items-center justify-between px-5 py-4 border-b border-calm-border dark:border-calmd-border">
+          <h2 className="text-xl font-semibold text-calm-ink dark:text-calmd-ink">Chat History</h2>
+          <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            className="p-2 hover:bg-calm-bg dark:hover:bg-calmd-bg rounded-full text-calm-muted dark:text-calmd-muted transition-colors"
           >
-            <X size={24} />
+            <X size={22} />
           </button>
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-4">
+        <div className="flex-1 overflow-y-auto p-5">
           {error ? (
             <div className="text-center py-8 text-red-500">
               {error}
             </div>
           ) : loading ? (
             <div className="text-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-              <p className="mt-2 text-gray-500">Loading chats...</p>
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-calm-accent dark:border-calmd-accent mx-auto"></div>
+              <p className="mt-2 text-calm-muted dark:text-calmd-muted">Loading chats…</p>
             </div>
           ) : selectedChat ? (
             <div>
               <button
                 onClick={() => setSelectedChat(null)}
-                className="mb-4 text-blue-500 hover:text-blue-600 flex items-center gap-2"
+                className="mb-4 text-calm-accent dark:text-calmd-accent hover:text-calm-accent-hover dark:hover:text-calmd-accent-hover flex items-center gap-2 font-medium"
               >
-                ← Back to Chat List
+                <ChevronLeft size={18} /> Back to all conversations
               </button>
               <div className="space-y-4">
-                {selectedChat.messages?.map((message, index) => (
-                  <div
-                    key={index}
-                    className={`p-4 rounded-lg ${
-                      message.sender === 'user'
-                        ? 'bg-blue-100 ml-auto'
-                        : 'bg-gray-100'
-                    } max-w-[80%]`}
-                  >
-                    <div className="font-semibold mb-1">
-                      {message.sender === 'user' ? 'You' : 'Lisa'}
+                {selectedChat.messages?.map((message, index) => {
+                  const isUser = message.sender === 'user';
+                  return (
+                    <div
+                      key={index}
+                      className={`flex flex-col ${isUser ? "items-end" : "items-start"}`}
+                    >
+                      <div
+                        className={`max-w-[80%] px-4 py-3 text-calm-ink dark:text-calmd-ink leading-relaxed ${
+                          isUser
+                            ? "bg-calm-user dark:bg-calmd-user rounded-2xl rounded-tr-sm"
+                            : "bg-calm-lisa dark:bg-calmd-lisa rounded-2xl rounded-tl-sm"
+                        }`}
+                      >
+                        {message.text}
+                      </div>
+                      <span className="text-[11px] text-calm-muted dark:text-calmd-muted mt-1 px-1">
+                        {isUser ? "You" : "Lisa"}
+                        {message.timestamp ? ` · ${formatTime(message.timestamp)}` : ""}
+                      </span>
                     </div>
-                    <div>{message.text}</div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           ) : (
-            <div className="grid gap-4">
+            <div className="grid gap-3">
               {chats.length === 0 ? (
-                <div className="text-center py-8 text-gray-500">
+                <div className="text-center py-8 text-calm-muted dark:text-calmd-muted">
                   No chat history found
                 </div>
               ) : (
@@ -121,18 +141,18 @@ const ChatHistoryModal = ({ isOpen, onClose }) => {
                   <div
                     key={chat._id}
                     onClick={() => setSelectedChat(chat)}
-                    className="border rounded-lg p-4 cursor-pointer hover:bg-gray-50 transition-colors"
+                    className="border border-calm-border dark:border-calmd-border rounded-xl p-4 cursor-pointer hover:bg-calm-bg dark:hover:bg-calmd-bg transition-colors"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-2 bg-blue-100 rounded-full">
-                        <MessageCircle size={20} className="text-blue-600" />
+                      <div className="p-2 bg-calm-lisa dark:bg-calmd-lisa rounded-full">
+                        <MessageCircle size={20} className="text-calm-accent dark:text-calmd-accent" />
                       </div>
                       <div className="flex-1">
-                        <div className="font-medium">Chat Session</div>
-                        <div className="text-sm text-gray-500">
+                        <div className="font-medium text-calm-ink dark:text-calmd-ink">Chat Session</div>
+                        <div className="text-sm text-calm-muted dark:text-calmd-muted">
                           {formatDate(chat.startedAt)}
                         </div>
-                        <div className="text-sm text-gray-500">
+                        <div className="text-sm text-calm-muted dark:text-calmd-muted">
                           {chat.messages?.length || 0} messages
                         </div>
                       </div>

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import { useChat } from "../hooks/useChat";
+
+const formatTime = (ts) => {
+  try {
+    return new Date(ts).toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+};
+
+const TypingIndicator = () => (
+  <div className="flex items-center gap-1 px-4 py-3 w-fit rounded-2xl rounded-tl-sm bg-calm-lisa dark:bg-calmd-lisa">
+    {[0, 1, 2].map((i) => (
+      <span
+        key={i}
+        className="w-1.5 h-1.5 rounded-full bg-calm-accent dark:bg-calmd-accent animate-typing"
+        style={{ animationDelay: `${i * 0.2}s` }}
+      />
+    ))}
+  </div>
+);
+
+export const ChatPanel = ({ isOpen, onClose }) => {
+  const { transcript, loading } = useChat();
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [transcript, loading, isOpen]);
+
+  return (
+    <div
+      className={`fixed top-0 right-0 h-full w-full sm:w-[400px] z-40 bg-calm-surface dark:bg-calmd-surface border-l border-calm-border dark:border-calmd-border shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
+        isOpen ? "translate-x-0" : "translate-x-full"
+      }`}
+      aria-hidden={!isOpen}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-4 border-b border-calm-border dark:border-calmd-border">
+        <div className="flex items-center gap-2">
+          <span className="w-2 h-2 rounded-full bg-calm-accent dark:bg-calmd-accent" />
+          <h2 className="font-semibold text-calm-ink dark:text-calmd-ink">Conversation with Lisa</h2>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-2 rounded-full text-calm-muted dark:text-calmd-muted hover:bg-calm-bg dark:hover:bg-calmd-bg transition-colors"
+          aria-label="Close conversation"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-5 py-6 space-y-4">
+        {transcript.length === 0 && !loading ? (
+          <div className="h-full flex flex-col items-center justify-center text-center text-calm-muted dark:text-calmd-muted">
+            <p className="text-calm-ink dark:text-calmd-ink font-medium mb-1">I'm here with you.</p>
+            <p className="text-sm">Share whatever is on your mind — there's no rush.</p>
+          </div>
+        ) : (
+          transcript.map((m, i) => {
+            const isUser = m.sender === "user";
+            return (
+              <div
+                key={i}
+                className={`flex flex-col ${isUser ? "items-end" : "items-start"}`}
+              >
+                <div
+                  className={`max-w-[80%] px-4 py-3 leading-relaxed ${
+                    isUser
+                      ? "bg-calm-user dark:bg-calmd-user text-calm-ink dark:text-calmd-ink rounded-2xl rounded-tr-sm"
+                      : m.isError
+                      ? "bg-red-50 text-red-700 rounded-2xl rounded-tl-sm"
+                      : "bg-calm-lisa dark:bg-calmd-lisa text-calm-ink dark:text-calmd-ink rounded-2xl rounded-tl-sm"
+                  }`}
+                >
+                  {m.text}
+                </div>
+                <span className="text-[11px] text-calm-muted dark:text-calmd-muted mt-1 px-1">
+                  {isUser ? "You" : "Lisa"} · {formatTime(m.timestamp)}
+                </span>
+              </div>
+            );
+          })
+        )}
+        {loading && (
+          <div className="flex flex-col items-start">
+            <TypingIndicator />
+            <span className="text-[11px] text-calm-muted dark:text-calmd-muted mt-1 px-1">
+              Lisa is typing…
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Experience.jsx
+++ b/frontend/src/components/Experience.jsx
@@ -57,7 +57,7 @@ export const Experience = () => {
   return (
     <>
       <CameraControls   ref={cameraControls} />
-      <Environment preset="sunset" />
+      <Environment preset="dawn" />
       <Suspense>
         <Dots position-y={1.75} position-x={-0.02} />
       </Suspense>

--- a/frontend/src/components/UI.jsx
+++ b/frontend/src/components/UI.jsx
@@ -1,19 +1,41 @@
 import { useRef, useState, useEffect } from "react";
 import { useChat } from "../hooks/useChat";
 import { Vid } from "./VideoFeed";
-import { Mic, MicOff, History, LogOut, User } from "lucide-react";
+import {
+  Mic,
+  MicOff,
+  History,
+  LogOut,
+  User,
+  Send,
+  Camera as CameraIcon,
+  MessageCircle,
+  Sun,
+  Moon,
+} from "lucide-react";
 import ChatHistoryModal from "./ChatHistorySidebar";
+import { ChatPanel } from "./ChatPanel";
+import { useTheme } from "../hooks/useTheme";
+
+const SUGGESTED_PROMPTS = [
+  "I've been feeling anxious lately",
+  "I can't sleep well",
+  "I just need someone to talk to",
+];
 
 const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:3000"; 
 
 export const UI = ({ hidden }) => {
   const input = useRef();
-  const { chat, loading, message, avatarModel, toggleAvatarModel } = useChat();
+  const { chat, loading, message, transcript, avatarModel, toggleAvatarModel } =
+    useChat();
+  const { theme, toggleTheme } = useTheme();
   const [user, setUser] = useState(null);
   const [showMenu, setShowMenu] = useState(false);
   const [Camera, setCamera] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [showChatHistory, setShowChatHistory] = useState(false);
+  const [showChatPanel, setShowChatPanel] = useState(false);
   const vidRef = useRef();
 
   // Speech recognition setup
@@ -77,6 +99,14 @@ export const UI = ({ hidden }) => {
     if (!loading && !message) {
       chat(text);
       input.current.value = "";
+      setShowChatPanel(true);
+    }
+  };
+
+  const sendPrompt = (text) => {
+    if (!loading && !message) {
+      chat(text);
+      setShowChatPanel(true);
     }
   };
 
@@ -102,37 +132,54 @@ export const UI = ({ hidden }) => {
       <div className="fixed inset-0 bg-transparent z-10">
         <div className="w-full h-full flex flex-col p-4">
           {/* Top Bar */}
-          <div className="w-full backdrop-blur-md bg-white bg-opacity-50 p-4 rounded-lg flex items-center justify-between">
+          <div className="w-full bg-calm-surface dark:bg-calmd-surface border border-calm-border dark:border-calmd-border p-4 rounded-2xl shadow-sm flex items-center justify-between">
             <div>
-              <h1 className="font-black text-xl">Mental Health Counselor</h1>
-              <p>Your Path to Mental Wellness</p>
+              <h1 className="font-black text-xl text-calm-ink dark:text-calmd-ink">Mind-Mate</h1>
+              <p className="text-sm text-calm-muted dark:text-calmd-muted">Your path to mental wellness</p>
             </div>
 
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
               {/* Avatar toggle */}
               <button
                 onClick={toggleAvatarModel}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all border border-gray-300 hover:border-gray-500 bg-white bg-opacity-80"
+                className="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all border border-calm-border dark:border-calmd-border hover:border-calm-accent dark:hover:border-calmd-accent text-calm-ink dark:text-calmd-ink bg-calm-bg dark:bg-calmd-bg"
                 title="Switch avatar"
               >
                 <span>{avatarModel === "swastik" ? "🧑 Swastik's version" : "🤖 Lisa"}</span>
               </button>
 
+              {/* Theme toggle */}
+              <button
+                onClick={toggleTheme}
+                className="p-2 rounded-full text-calm-ink dark:text-calmd-ink hover:bg-calm-bg dark:hover:bg-calmd-bg transition-colors"
+                title={theme === "dark" ? "Switch to light" : "Switch to dark"}
+              >
+                {theme === "dark" ? <Sun size={22} /> : <Moon size={22} />}
+              </button>
+
+              <button
+                onClick={() => setShowChatPanel((v) => !v)}
+                className="p-2 rounded-full text-calm-ink dark:text-calmd-ink hover:bg-calm-bg dark:hover:bg-calmd-bg transition-colors"
+                title="Conversation"
+              >
+                <MessageCircle size={22} />
+              </button>
+
               <button
                 onClick={() => setShowChatHistory(true)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                className="p-2 rounded-full text-calm-ink dark:text-calmd-ink hover:bg-calm-bg dark:hover:bg-calmd-bg transition-colors"
                 title="Chat History"
               >
-                <History size={24} />
+                <History size={22} />
               </button>
-              
+
               {user && (
                 <div className="profile-menu relative">
                   <div
-                    className="flex items-center gap-2 cursor-pointer p-2 hover:bg-gray-100 rounded-lg"
+                    className="flex items-center gap-2 cursor-pointer p-2 hover:bg-calm-bg dark:hover:bg-calmd-bg rounded-lg"
                     onClick={() => setShowMenu(!showMenu)}
                   >
-                    <div className="w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center text-white">
+                    <div className="w-8 h-8 rounded-full bg-calm-accent dark:bg-calmd-accent flex items-center justify-center text-white">
                       {user.picture ? (
                         <img
                           src={user.picture}
@@ -147,18 +194,18 @@ export const UI = ({ hidden }) => {
                         <User size={20} />
                       )}
                     </div>
-                    <span className="font-medium">{user.name || user.email}</span>
+                    <span className="font-medium text-calm-ink dark:text-calmd-ink">{user.name || user.email}</span>
                   </div>
 
                   {showMenu && (
-                    <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border overflow-hidden">
-                      <div className="p-3 border-b">
-                        <p className="font-medium">{user.name}</p>
-                        <p className="text-sm text-gray-500">{user.email}</p>
+                    <div className="absolute right-0 mt-2 w-48 bg-calm-surface dark:bg-calmd-surface rounded-xl shadow-lg border border-calm-border dark:border-calmd-border overflow-hidden">
+                      <div className="p-3 border-b border-calm-border dark:border-calmd-border">
+                        <p className="font-medium text-calm-ink dark:text-calmd-ink">{user.name}</p>
+                        <p className="text-sm text-calm-muted dark:text-calmd-muted">{user.email}</p>
                       </div>
                       <button
                         onClick={handleLogout}
-                        className="w-full px-4 py-2 text-left text-red-600 hover:bg-gray-50 flex items-center gap-2"
+                        className="w-full px-4 py-2 text-left text-red-600 hover:bg-calm-bg dark:hover:bg-calmd-bg flex items-center gap-2"
                       >
                         <LogOut size={18} />
                         <span>Logout</span>
@@ -170,57 +217,86 @@ export const UI = ({ hidden }) => {
             </div>
           </div>
 
-          {/* Chat Messages */}
+          {/* Spacer — avatar (Canvas) shows through here */}
           <div className="flex-grow" />
 
           {/* Input Area */}
-          <div className="w-full max-w-screen-sm mx-auto flex items-center gap-2">
-            <input
-              className="flex-1 placeholder:text-gray-800 placeholder:italic p-4 rounded-md bg-white shadow-lg"
-              placeholder="Type a message..."
-              ref={input}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  sendMessage();
-                }
-              }}
-            />
-            <button
-              onClick={toggleRecording}
-              className={`p-4 rounded-md shadow-lg ${
-                isRecording 
-                  ? 'bg-red-500 hover:bg-red-600' 
-                  : 'bg-blue-500 hover:bg-blue-600'
-              } text-white`}
-            >
-              {isRecording ? <MicOff size={24} /> : <Mic size={24} />}
-            </button>
-            <button
-              disabled={loading || message}
-              onClick={sendMessage}
-              className={`bg-blue-500 hover:bg-blue-600 text-white p-4 px-10 font-semibold uppercase rounded-md shadow-lg ${
-                loading || message ? "cursor-not-allowed opacity-30" : ""
-              }`}
-            >
-              Send
-            </button>
-            <button
-              onClick={() => {
-                const frame = vidRef.current;
-                frame.style.display = Camera ? "none" : "block";
-                setCamera(!Camera);
-              }}
-              className="bg-pink-500 hover:bg-pink-600 text-white p-4 rounded-md shadow-lg"
-            >
-              📷
-            </button>
+          <div className="w-full max-w-screen-sm mx-auto">
+            {/* Suggested prompts — only before the conversation starts */}
+            {transcript.length === 0 && (
+              <div className="flex flex-wrap justify-center gap-2 mb-3">
+                {SUGGESTED_PROMPTS.map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => sendPrompt(p)}
+                    disabled={loading || message}
+                    className="px-4 py-2 text-sm rounded-full bg-calm-surface dark:bg-calmd-surface border border-calm-border dark:border-calmd-border text-calm-ink dark:text-calmd-ink hover:border-calm-accent dark:hover:border-calmd-accent shadow-sm transition-colors disabled:opacity-40"
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 bg-calm-surface dark:bg-calmd-surface border border-calm-border dark:border-calmd-border rounded-full shadow-sm px-2 py-2">
+              <input
+                className="flex-1 bg-transparent px-4 py-2 text-calm-ink dark:text-calmd-ink placeholder:text-calm-muted dark:placeholder:text-calmd-muted focus:outline-none"
+                placeholder="Type a message…"
+                ref={input}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    sendMessage();
+                  }
+                }}
+              />
+              {/* Camera toggle */}
+              <button
+                onClick={() => {
+                  const frame = vidRef.current;
+                  frame.style.display = Camera ? "none" : "block";
+                  setCamera(!Camera);
+                }}
+                className="p-2.5 rounded-full text-calm-muted dark:text-calmd-muted hover:bg-calm-bg dark:hover:bg-calmd-bg hover:text-calm-accent dark:hover:text-calmd-accent transition-colors"
+                title="Toggle camera"
+              >
+                <CameraIcon size={20} />
+              </button>
+              {/* Mic toggle */}
+              <button
+                onClick={toggleRecording}
+                className={`p-2.5 rounded-full transition-colors ${
+                  isRecording
+                    ? "bg-red-500 text-white hover:bg-red-600"
+                    : "text-calm-muted dark:text-calmd-muted hover:bg-calm-bg dark:hover:bg-calmd-bg hover:text-calm-accent dark:hover:text-calmd-accent"
+                }`}
+                title={isRecording ? "Stop recording" : "Start recording"}
+              >
+                {isRecording ? <MicOff size={20} /> : <Mic size={20} />}
+              </button>
+              {/* Send */}
+              <button
+                disabled={loading || message}
+                onClick={sendMessage}
+                className={`p-2.5 rounded-full bg-calm-accent dark:bg-calmd-accent text-white hover:bg-calm-accent-hover dark:hover:bg-calmd-accent-hover transition-colors ${
+                  loading || message ? "cursor-not-allowed opacity-40" : ""
+                }`}
+                title="Send"
+              >
+                <Send size={20} />
+              </button>
+            </div>
           </div>
         </div>
       </div>
 
-      <ChatHistoryModal 
-        isOpen={showChatHistory} 
-        onClose={() => setShowChatHistory(false)} 
+      <ChatPanel
+        isOpen={showChatPanel}
+        onClose={() => setShowChatPanel(false)}
+      />
+
+      <ChatHistoryModal
+        isOpen={showChatHistory}
+        onClose={() => setShowChatHistory(false)}
       />
       
       <div id="Vid" ref={vidRef} className="fixed bottom-0 right-0 m-[50px] z-20">

--- a/frontend/src/hooks/useChat.jsx
+++ b/frontend/src/hooks/useChat.jsx
@@ -5,7 +5,13 @@ const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:3000";
 const ChatContext = createContext();
 
 export const ChatProvider = ({ children }) => {
-  const chat = async (message) => {
+  const chat = async (text) => {
+    if (!text?.trim()) return;
+    // Persist the user's turn in the visible transcript immediately
+    setTranscript((prev) => [
+      ...prev,
+      { sender: "user", text, timestamp: new Date().toISOString() },
+    ]);
     try {
       setLoading(true);
       const response = await fetch(`${apiUrl}/chat`, {
@@ -15,7 +21,7 @@ export const ChatProvider = ({ children }) => {
           "Accept": "application/json",
         },
         credentials: "include",
-        body: JSON.stringify({ message }),
+        body: JSON.stringify({ message: text }),
       });
 
       if (!response.ok) {
@@ -23,14 +29,34 @@ export const ChatProvider = ({ children }) => {
       }
 
       const data = await response.json();
-      
+
       if (data.messages && Array.isArray(data.messages)) {
-        setMessages(prevMessages => [...prevMessages, ...data.messages]);
+        // Drive the avatar playback queue
+        setMessages((prevMessages) => [...prevMessages, ...data.messages]);
+        // Append Lisa's turns to the persistent transcript
+        setTranscript((prev) => [
+          ...prev,
+          ...data.messages.map((m) => ({
+            sender: "bot",
+            text: m.text,
+            facialExpression: m.facialExpression,
+            timestamp: new Date().toISOString(),
+          })),
+        ]);
       } else {
         console.error('Invalid response format:', data);
       }
     } catch (error) {
       console.error('Chat error:', error);
+      setTranscript((prev) => [
+        ...prev,
+        {
+          sender: "bot",
+          text: "Sorry, I couldn't reach you just now. Please try again in a moment.",
+          isError: true,
+          timestamp: new Date().toISOString(),
+        },
+      ]);
     } finally {
       setLoading(false);
     }
@@ -38,6 +64,7 @@ export const ChatProvider = ({ children }) => {
 
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState(null);
+  const [transcript, setTranscript] = useState([]);
   const [loading, setLoading] = useState(false);
   const [avatarModel, setAvatarModel] = useState("default");
   const toggleAvatarModel = () =>
@@ -60,6 +87,7 @@ export const ChatProvider = ({ children }) => {
       value={{
         chat,
         message,
+        transcript,
         onMessagePlayed,
         loading,
         avatarModel,

--- a/frontend/src/hooks/useTheme.jsx
+++ b/frontend/src/hooks/useTheme.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof document !== "undefined") {
+      return document.documentElement.classList.contains("dark")
+        ? "dark"
+        : "light";
+    }
+    return "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    try {
+      localStorage.setItem("theme", theme);
+    } catch (e) {}
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((t) => (t === "dark" ? "light" : "dark"));
+
+  return { theme, toggleTheme };
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,9 +14,14 @@
 
 body {
   margin: 0;
-  background-color: #a8fab3;
-  /* background-image: linear-gradient(19deg, #a8faf2 0%, #1783ef 100%); */
-  background-image: url(../public/background-optimized.jpg);
+  background-color: #cde3dd;
+  background-image: linear-gradient(160deg, #d6e8e3 0%, #bcd8e4 45%, #a9cdc2 100%);
+  transition: background-color 0.4s ease, background-image 0.4s ease;
+}
+
+html.dark body {
+  background-color: #0a0f0c;
+  background-image: radial-gradient(circle at 50% 35%, #163021 0%, #0c1410 55%, #060908 100%);
 }
 
 body.greenScreen {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,10 +1,45 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: "class",
   theme: {
     extend: {
       fontFamily: {
         sans: ["Inter", "sans-serif"],
+      },
+      colors: {
+        calm: {
+          bg: "#F4F7F6", // warm off-white page
+          surface: "#FFFFFF",
+          user: "#DCEBE8", // soft sage (user bubble)
+          lisa: "#E6EEF5", // pale blue (Lisa bubble)
+          accent: "#5B8C82", // muted teal (buttons)
+          "accent-hover": "#4A7269",
+          ink: "#2E3A36", // soft charcoal text
+          muted: "#7A8783", // secondary text
+          border: "#E2E8E5",
+        },
+        // Dark theme — deep green/black
+        calmd: {
+          bg: "#0D1410",
+          surface: "#16201B",
+          user: "#2A3D35", // dark sage
+          lisa: "#243038", // dark blue-gray
+          accent: "#6FB39E", // brighter teal for contrast on dark
+          "accent-hover": "#82C4AF",
+          ink: "#E4EBE8", // light text
+          muted: "#8A998F", // secondary text
+          border: "#2A3530",
+        },
+      },
+      keyframes: {
+        typing: {
+          "0%, 60%, 100%": { opacity: "0.3", transform: "translateY(0)" },
+          "30%": { opacity: "1", transform: "translateY(-3px)" },
+        },
+      },
+      animation: {
+        typing: "typing 1.4s infinite ease-in-out",
       },
     },
   },


### PR DESCRIPTION
## Why

The previous interface had no visible conversation in the main view — the "Chat Messages" area was an empty `<div className="flex-grow" />` spacer, and messages only existed inside a history modal. The palette (sunset 3D lighting + pink accents) also worked against a calming mental-health context.

## What changed

**Conversation is now visible**
- Split the avatar playback queue from a persistent `transcript` in `useChat` so messages no longer vanish after Lisa speaks them.
- New `ChatPanel` that slides in from the right: message bubbles, timestamps, a "Lisa is typing…" indicator, auto-scroll, and a warm empty state. Auto-opens on send.

**Calming visual system**
- Soft blue-green ("Calm-style") palette as Tailwind tokens.
- Swapped 3D `Environment` `sunset` → `dawn` (removes the pink cast on the avatar) and replaced the background image with a gentle gradient.

**Input bar**
- Unified the three mismatched buttons (blue circle mic / text "Send" / pink emoji 📷) into consistent icon buttons.
- Added tappable suggested-prompt chips for first-time users.

**History modal**
- Re-themed on the new palette + added per-message timestamps (already stored, never rendered).

**Dark / light theme**
- `darkMode: "class"` + a deep green-black dark palette, Sun/Moon toggle, `localStorage` persistence, no-flash init.

## Notes
- Avatar stays center-stage; only the scene lighting changed.
- Build passes (`npm run build`). Pure frontend; no API changes.